### PR TITLE
feat: Dynamically load repos from Github App installations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 # will have compiled files and executables
 debug/
 target/
+.DS_STORE
 
 # Remove Cargo.lock from gitignore if creating an executable, leave it for libraries
 # More information here https://doc.rust-lang.org/cargo/guide/cargo-toml-vs-cargo-lock.html

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2795,6 +2795,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_qs"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd34f36fe4c5ba9654417139a9b3a20d2e1de6012ee678ad14d240c22c78d8d6"
+dependencies = [
+ "axum",
+ "futures",
+ "percent-encoding",
+ "serde",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3648,6 +3662,8 @@ dependencies = [
  "axum-embed",
  "chrono",
  "clap",
+ "http 1.1.0",
+ "indexmap 2.5.0",
  "jsonwebtoken",
  "maud",
  "octocrab",
@@ -3657,8 +3673,10 @@ dependencies = [
  "rust-embed",
  "serde",
  "serde_json",
+ "serde_qs",
  "service_conventions",
  "tera",
+ "thiserror",
  "tokio",
  "toml",
  "tonic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,7 @@ rust-embed = { version = "8.3.0", features = ["axum", "mime-guess", "mime_guess"
 axum-embed = "0.1.0"
 redacted = "0.2.0"
 jsonwebtoken = "9.3.0"
+indexmap = { version = "2.5.0", features = ["serde"] }
+serde_qs = { version = "0.13.0", features = ["axum", "tracing"] }
+thiserror = "1.0.63"
+http = "1.1.0"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A form to write structured data into Github. Used for writing notes to static fi
 
 Relies on OIDC login (tested with kanidm).
 
+Requires a Github App for API permissions to Github.
+
 
 ```
 kanidm system oauth2 update-scope-map w2z <group> openid profile email

--- a/src/backends/github.rs
+++ b/src/backends/github.rs
@@ -1,0 +1,289 @@
+use crate::templating;
+
+use crate::UploadableFile;
+use octocrab::models::repos::CommitAuthor;
+use octocrab::models::{InstallationRepositories, InstallationToken};
+use octocrab::Octocrab;
+use redacted::FullyRedacted;
+use serde::Deserialize;
+
+use http;
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct GithubBackend {
+    config: GithubConfig,
+}
+
+impl GithubBackend {
+    pub fn from_config(config: GithubConfig) -> Self {
+        GithubBackend { config }
+    }
+
+    pub async fn sites(&self) -> anyhow::Result<Vec<GithubSite>> {
+        let o = self.config.build_octocrab().await?;
+        let mut v = vec![];
+
+        let installed_repos: InstallationRepositories = o
+            .get("/installation/repositories", None::<&()>)
+            .await
+            .unwrap();
+        for repo in installed_repos.repositories {
+            tracing::debug!(installation= ?repo, "repo");
+            if let Some(owner) = repo.owner {
+                let n = format!("{}/{}", owner.login, repo.name);
+
+                v.push(GithubSite {
+                    name: n,
+                    owner: owner.login,
+                    repo: repo.name,
+                })
+            }
+        }
+
+        Ok(v)
+    }
+
+    pub async fn get_site_config(&self, site: &GithubSite) -> anyhow::Result<SiteConfig> {
+        let octocrab = self.config.build_octocrab().await?;
+        let mut content = octocrab
+            .repos(&site.owner, &site.repo)
+            .get_content()
+            .path("w2z.toml")
+            .r#ref("main")
+            .send()
+            .await?;
+        let contents = content.take_items();
+        let c = &contents[0];
+        if let Some(decoded_content) = c.decoded_content() {
+            Ok(toml::from_str(&decoded_content)?)
+        } else {
+            Err(anyhow::anyhow!("Couldn't do it!"))
+        }
+    }
+
+    pub async fn write_file(self, site: GithubSite, uf: &UploadableFile) -> anyhow::Result<bool> {
+        //let now = Local::now();
+        //let id = uuid::Uuid::new_v4();
+        //let filename = format!("content/notes/{}-{id}.md", now.format("%Y/%Y-%m-%dT%H:%M:%SZ"));
+        //tracing::info!("Filename {:?}", filename);
+
+        //let new_contents = format!("+++\n+++\n{contents}");
+
+        let octocrab = self.config.build_octocrab().await?;
+        octocrab
+            .repos(site.owner, site.repo)
+            .create_file(&uf.filename, "Create note", &uf.contents)
+            .branch(self.config.branch()?)
+            .commiter(CommitAuthor {
+                name: "Octocat".to_string(),
+                email: "octocat@github.com".to_string(),
+                date: None,
+            })
+            .author(CommitAuthor {
+                name: "Ferris".to_string(),
+                email: "ferris@rust-lang.org".to_string(),
+                date: None,
+            })
+            .send()
+            .await?;
+        Ok(true)
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct GithubConfig {
+    app_id: u64,
+    app_key: FullyRedacted<String>,
+
+    #[serde(default = "default_branch")]
+    branch: String,
+}
+
+fn default_branch() -> String {
+    "main".to_string()
+}
+
+use octocrab::params::apps::CreateInstallationAccessToken;
+use url::Url;
+impl GithubConfig {
+    async fn build_octocrab(&self) -> anyhow::Result<Octocrab> {
+        let o = self.build_app_octocrab().await?;
+
+        let installations = o.apps().installations().send().await?.take_items();
+
+        let create_access_token = CreateInstallationAccessToken::default();
+
+        // By design, tokens are not forwarded to urls that contain an authority. This means we need to
+        // extract the path from the url and use it to make the request.
+        let access_token_url = Url::parse(installations[0].access_tokens_url.as_ref().unwrap())?;
+
+        let access: InstallationToken = o
+            .post(access_token_url.path(), Some(&create_access_token))
+            .await?;
+
+        let octocrab = octocrab::OctocrabBuilder::new()
+            .personal_token(access.token)
+            .build();
+        Ok(octocrab?)
+    }
+
+    async fn build_app_octocrab(&self) -> anyhow::Result<Octocrab> {
+        let k = jsonwebtoken::EncodingKey::from_rsa_pem(self.app_key.as_bytes())?;
+        Ok(Octocrab::builder().app(self.app_id.into(), k).build()?)
+    }
+
+    fn repository(&self) -> anyhow::Result<String> {
+        Ok("philipcristiano.com".to_string())
+    }
+
+    fn owner(&self) -> anyhow::Result<String> {
+        Ok("philipcristiano".to_string())
+    }
+    fn branch(&self) -> anyhow::Result<String> {
+        Ok(self.branch.clone())
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct GithubSite {
+    pub name: String,
+    owner: String,
+    repo: String,
+}
+
+impl From<SiteParams> for GithubSite {
+    fn from(item: SiteParams) -> Self {
+        let n = format!("{}/{}", item.owner, item.repo);
+
+        GithubSite {
+            name: n,
+            owner: item.owner,
+            repo: item.repo,
+        }
+    }
+}
+
+use axum::{
+    extract::{FromRef, Path, RawForm, State},
+    response::{IntoResponse, Redirect, Response},
+    Form, Router,
+};
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct SiteParams {
+    owner: String,
+    repo: String,
+}
+use crate::{AppError, AppState};
+pub async fn axum_get_site(
+    State(app_state): State<AppState>,
+    Path(site_params): Path<SiteParams>,
+    user: Option<service_conventions::oidc::OIDCUser>,
+) -> Result<Response, AppError> {
+    let site: GithubSite = site_params.into();
+    let config = &app_state.backend.get_site_config(&site).await?;
+    let path_pref = format!("/b/github/{}", &site.name);
+    let field_prefix = "fields".to_string();
+
+    let body = maud::html! {
+        @for template in config.templates.clone().into_iter() {
+            p {
+              h2 {(template.0)}
+              form method="post" action={(&path_pref) "/new/" (template.0)} {
+                @for input_field in &template.1.input_fields {
+                    (input_field.form_markup(&field_prefix))
+                }
+                input type="submit" class="border" {}
+              }
+              @for msg in &template.1.config_messages() {
+                  p {(msg)}
+
+              }
+            }
+        }
+
+    };
+    Ok(body.into_response())
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct SiteConfig {
+    templates: indexmap::IndexMap<String, templating::Template>,
+}
+
+impl SiteConfig {
+
+    fn get_template(self, name: String) -> Option<templating::Template> {
+        self.templates.into_iter().find(|t| t.0 == name).map(|(_s, t)| t)
+    }
+
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct TemplatePostParams {
+    owner: String,
+    repo: String,
+    template_name: String,
+}
+
+impl From<TemplatePostParams> for GithubSite {
+    fn from(item: TemplatePostParams) -> Self {
+        let n = format!("{}/{}", item.owner, item.repo);
+
+        GithubSite {
+            name: n,
+            owner: item.owner,
+            repo: item.repo,
+        }
+    }
+}
+
+use serde_qs::Config;
+pub async fn axum_post_template(
+    State(app_state): State<AppState>,
+    Path(path_params): Path<TemplatePostParams>,
+    RawForm(form): RawForm,
+) -> Result<Response, AppError> {
+    tracing::info!("Post form {:?}", form);
+
+    let qs = Config::new(5, false);
+    let site: GithubSite = path_params.clone().into();
+    let config = &app_state.backend.get_site_config(&site).await?;
+    let post_data: templating::Blob = qs.deserialize_bytes(&form)?;
+    tracing::info!("Post form data{:?}", post_data);
+
+    let maybe_template = config.to_owned().get_template(path_params.template_name);
+    if let Some(template) = maybe_template{
+        let file_contents = template.as_toml( post_data)?;
+        let file_path = template.rendered_path()?;
+        let uf = crate::UploadableFile {
+            filename: file_path,
+            contents: file_contents,
+        };
+        let _ = &app_state.backend.write_file(site, &uf).await?;
+        Ok(Redirect::to("/").into_response())
+    } else {
+        return Ok((http::status::StatusCode::NOT_FOUND, "").into_response())
+
+    }
+
+
+    //let uf = render_like(&app_state.templates, form.in_like_of, text);
+}
+
+fn render_like(t: &tera::Tera, in_reply_to: String, form_text: String) -> UploadableFile {
+    let mut context = tera::Context::new();
+    context.insert("contents", &form_text);
+    context.insert("in_like_of", &in_reply_to);
+    context.insert("uuid", &uuid::Uuid::new_v4().to_string());
+
+    for name in t.get_template_names() {
+        tracing::info!("Template: {:?}", name);
+    }
+    let path = t.render("like.filename", &context);
+    let body = t.render("like.body", &context);
+    UploadableFile {
+        filename: path.expect("could not render"),
+        contents: body.expect("could not render"),
+    }
+}

--- a/src/backends/mod.rs
+++ b/src/backends/mod.rs
@@ -1,0 +1,1 @@
+pub mod github;

--- a/src/templating.rs
+++ b/src/templating.rs
@@ -1,0 +1,460 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(tag = "type")]
+pub enum InputField {
+    #[serde(alias = "string")]
+    String { name: String },
+    #[serde(alias = "text")]
+    Text { name: String },
+    #[serde(alias = "datetime")]
+    DateTime { name: String, default_now: bool },
+    #[serde(alias = "object")]
+    Object {
+        name: String,
+        input_fields: Vec<InputField>,
+    },
+}
+
+impl InputField {
+    pub fn name(&self) -> &String {
+        match self {
+            InputField::Text { name } => name,
+            InputField::String { name } => name,
+            InputField::Object { name, .. } => name,
+            InputField::DateTime { name, .. } => name,
+        }
+    }
+    pub fn form_markup(&self, prefix: &String) -> maud::Markup {
+        match self {
+            InputField::Text { name } => {
+                let field_name = format!("{}[{}]", prefix, name);
+                maud::html! {
+                    label for={(name)} { (name)}
+                    textarea white-space="pre-wrap" id={(&field_name)} class="border min-w-full" name={(&field_name)} {}
+                }
+            }
+            InputField::String { name } => {
+                let field_name = format!("{}[{}]", prefix, name);
+                maud::html! {
+                    label for={(&field_name)} { (&field_name)}
+                    input id={(&field_name)} class="border min-w-full" name={(&field_name)} {}
+                }
+            }
+            InputField::Object { name, input_fields } => {
+                let field_name = format!("{}[{}]", prefix, name);
+                maud::html! {
+                    label for={(&field_name)} { (&field_name)}
+                    @for if_field in input_fields {
+                        (if_field.form_markup(&field_name))
+
+                    }
+                }
+            }
+            InputField::DateTime { name, .. } => {
+                let field_name = format!("{}[{}]", prefix, name);
+                // TODO default shouldn't be handled by omitting things
+                maud::html! {
+                    label for={(&field_name)} { (&field_name)}
+                    span {"Date will be set automatically"}
+                }
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum PostTypes {
+    String(String),
+    Object(HashMap<String, PostTypes>),
+}
+
+impl PostTypes {
+    fn value_string(self) -> Result<String, TemplateError> {
+        match self {
+            PostTypes::String(s) => Ok(s),
+            PostTypes::Object(m) => Err(TemplateError::FieldDataError(
+                "Cannot convert to string".to_string(),
+            )),
+        }
+    }
+
+    fn value_hm(self) -> Result<HashMap<String, PostTypes>, TemplateError> {
+        match self {
+            PostTypes::Object(m) => Ok(m),
+            PostTypes::String(s) => Err(TemplateError::FieldDataError(
+                "Cannot convert to hashmap".to_string(),
+            )),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Serialize)]
+struct DataContext {
+    now: chrono::DateTime<chrono::Utc>,
+}
+impl Default for DataContext {
+    fn default() -> Self {
+        Self {
+            now: chrono::Utc::now(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct Blob {
+    fields: HashMap<String, PostTypes>,
+}
+
+impl Blob {
+    fn to_valid_structure(
+        self,
+        input_fields: Vec<InputField>,
+        context: DataContext,
+    ) -> Result<indexmap::IndexMap<String, FieldValue>, TemplateError> {
+        Blob::hm_to_valid_structure(self.fields, input_fields, context)
+    }
+
+    fn hm_to_valid_structure(
+        hm: HashMap<String, PostTypes>,
+        input_fields: Vec<InputField>,
+        context: DataContext,
+    ) -> Result<indexmap::IndexMap<String, FieldValue>, TemplateError> {
+        let mut im = indexmap::IndexMap::new();
+        for input_field in input_fields {
+            let maybe_blob_value = hm.get(input_field.name());
+            if let Some(blob_value) = maybe_blob_value {
+                let field_value =
+                    FieldValue::try_new(&input_field, blob_value.to_owned(), context)?;
+                im.insert(input_field.name().clone(), field_value);
+            } else {
+                if let Some(default_fv) = FieldValue::try_new_default(&input_field, context) {
+                    im.insert(input_field.name().clone(), default_fv);
+                } else {
+                    return Err(TemplateError::MissingField {
+                        field: input_field.name().to_owned(),
+                    });
+                }
+                // return error
+            }
+        }
+        Ok(im)
+    }
+}
+
+use thiserror::Error;
+#[derive(Error, Debug, PartialEq, Eq)]
+pub enum TemplateError {
+    #[error("Field is missing")]
+    MissingField { field: String },
+    #[error("Error with data in a field")]
+    FieldDataError(String),
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum FieldValue {
+    #[serde(alias = "string")]
+    String(String),
+    #[serde(alias = "text")]
+    Text(String),
+    #[serde(alias = "object")]
+    Object(indexmap::IndexMap<String, FieldValue>),
+    #[serde(alias = "datetime")]
+    DateTime(chrono::DateTime<chrono::Utc>),
+}
+
+impl FieldValue {
+    fn try_new(
+        input_field: &InputField,
+        value: PostTypes,
+        context: DataContext,
+    ) -> Result<FieldValue, TemplateError> {
+        match input_field {
+            InputField::String { name } => Ok(FieldValue::String(value.value_string()?)),
+            InputField::Text { name } => Ok(FieldValue::Text(value.value_string()?)),
+            InputField::DateTime { name, default_now } => {
+                let now = chrono::Utc::now();
+                Ok(FieldValue::DateTime(now))
+            }
+            InputField::Object { name, input_fields } => {
+                let d = Blob::hm_to_valid_structure(
+                    value.value_hm()?,
+                    input_fields.to_owned(),
+                    context,
+                )?;
+                Ok(FieldValue::Object(d))
+            }
+        }
+    }
+    fn try_new_default(input_field: &InputField, context: DataContext) -> Option<FieldValue> {
+        match input_field {
+            InputField::DateTime { name, default_now } => {
+                if default_now.clone() {
+                    return Some(FieldValue::DateTime(context.now));
+                } else {
+                    return None;
+                }
+            }
+            _ => None,
+        }
+    }
+
+    fn as_body_string(self) -> String {
+        match self {
+            FieldValue::String(s) => s,
+            FieldValue::Text(t) => t,
+            FieldValue::Object(..) => "[object]".to_string(),
+            FieldValue::DateTime(now) => now.to_string(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct Template {
+    pub input_fields: Vec<InputField>,
+    pub path: String,
+    pub body: String,
+}
+
+impl Template {
+    pub fn config_messages(&self) -> Vec<String> {
+        let mut m = vec![];
+
+        if let Err(e) = self.renderer(&self.path) {
+            m.push(format!("Could not parse path: {:?}", e));
+        }
+        if let Err(e) = self.renderer(&self.body) {
+            m.push(format!("Could not parse body: {:?}", e));
+        }
+
+        m
+    }
+
+    fn renderer(&self, tmpl: &String) -> anyhow::Result<tera::Tera> {
+        let mut t = tera::Tera::default();
+        t.add_raw_template("tmpl", tmpl)?;
+        Ok(t)
+    }
+
+    pub fn rendered_path(&self) -> anyhow::Result<String> {
+        let context = tera::Context::new();
+        let r = self.renderer(&self.path)?;
+        Ok(r.render("tmpl", &context)?)
+    }
+
+    pub fn as_toml(&self, data: Blob) -> anyhow::Result<String> {
+        let structured_data =
+            data.to_valid_structure(self.input_fields.clone(), DataContext::default())?;
+
+        let file_contents = format_toml_frontmatter_file(structured_data);
+        Ok(file_contents)
+    }
+}
+
+pub fn create_tera(templates: &HashMap<String, Template>) -> tera::Tera {
+    let mut t = tera::Tera::default();
+    let mut vec_ts: Vec<(String, String)> = Vec::new();
+
+    for (template_id, template_config) in templates.iter() {
+        let filename_name = format!("{}.filename", template_id);
+        let body_name = format!("{}.body", template_id);
+        tracing::debug!(
+            "Adding template: {}, {}",
+            filename_name,
+            template_config.path
+        );
+        tracing::debug!("Adding template: {}, {}", body_name, template_config.body);
+        vec_ts.push((filename_name, template_config.path.clone()));
+        vec_ts.push((body_name, template_config.body.clone()));
+    }
+    t.add_raw_templates(vec_ts).expect("Parse templates");
+    t
+}
+
+fn format_toml_frontmatter_file(mut data: indexmap::IndexMap<String, FieldValue>) -> String {
+    println!("Data {:?}", &data);
+    let body = data.shift_remove("body");
+
+    let fm = toml::to_string(&data).unwrap();
+    if let Some(body) = body {
+        let body_s = body.as_body_string();
+        format!("+++\n{fm}+++\n\n{body_s}\n")
+    } else {
+        format!("+++\n{fm}+++\n")
+    }
+}
+
+#[cfg(test)]
+mod test_structure {
+
+    use super::*;
+
+    #[test]
+    fn single_text_field() {
+        let text_field = InputField::Text {
+            name: "title".to_string(),
+        };
+        let mut fields_hm = HashMap::new();
+        let val = PostTypes::String("Hello World!".to_string());
+        fields_hm.insert("title".to_string(), val);
+
+        let data = Blob { fields: fields_hm };
+
+        let expected = r#"+++
+title = "Hello World!"
++++
+"#;
+
+        let structured_data = data
+            .to_valid_structure(vec![text_field], DataContext::default())
+            .unwrap();
+
+        let file_contents = format_toml_frontmatter_file(structured_data);
+
+        assert_eq!(file_contents, expected);
+    }
+
+    #[test]
+    fn single_text_field_missing_data() {
+        let text_field = InputField::Text {
+            name: "title".to_string(),
+        };
+        let fields_hm = HashMap::new();
+        let data = Blob { fields: fields_hm };
+
+        let expected = TemplateError::MissingField {
+            field: "title".to_string(),
+        };
+        let maybe_structured_data = data
+            .to_valid_structure(vec![text_field], DataContext::default())
+            .unwrap_err();
+        assert_eq!(maybe_structured_data, expected);
+    }
+
+    #[test]
+    fn single_string_field() {
+        let text_field = InputField::String {
+            name: "title".to_string(),
+        };
+        let mut fields_hm = HashMap::new();
+        let val = PostTypes::String("Hello World!".to_string());
+        fields_hm.insert("title".to_string(), val);
+
+        let data = Blob { fields: fields_hm };
+
+        let expected = r#"+++
+title = "Hello World!"
++++
+"#;
+
+        let structured_data = data
+            .to_valid_structure(vec![text_field], DataContext::default())
+            .unwrap();
+
+        let file_contents = format_toml_frontmatter_file(structured_data);
+
+        assert_eq!(file_contents, expected);
+    }
+
+    #[test]
+    fn single_datetime_field() {
+        let dt_field = InputField::DateTime {
+            name: "date".to_string(),
+            default_now: true,
+        };
+        let fields_hm = HashMap::new();
+
+        let data = Blob { fields: fields_hm };
+        let context = DataContext {
+            now: chrono::Utc::now(),
+        };
+        println!("{}", toml::to_string(&context).unwrap());
+
+        // Format to match
+        // https://github.com/pitdicker/chrono/blob/2d2062f576f306222217abb866feaa3dbfda94a2/src/datetime/serde.rs#L45
+        // as precision can change with the default serde implementation depending on the platform
+        let expected = format!(
+            r#"+++
+date = "{}"
++++
+"#,
+            context
+                .now
+                .to_rfc3339_opts(chrono::format::SecondsFormat::AutoSi, true)
+        );
+
+        let structured_data = data.to_valid_structure(vec![dt_field], context).unwrap();
+
+        let file_contents = format_toml_frontmatter_file(structured_data);
+
+        assert_eq!(file_contents, expected);
+    }
+    #[test]
+    fn string_and_toml_content_field() {
+        let string_field = InputField::String {
+            name: "title".to_string(),
+        };
+        let text_field = InputField::String {
+            name: "body".to_string(),
+        };
+        let mut fields_hm = HashMap::new();
+        let sval = PostTypes::String("Hello World!".to_string());
+        fields_hm.insert("title".to_string(), sval);
+        let tval = PostTypes::String("Text body!".to_string());
+        fields_hm.insert("body".to_string(), tval);
+
+        let data = Blob { fields: fields_hm };
+
+        let expected = r#"+++
+title = "Hello World!"
++++
+
+Text body!
+"#;
+
+        let structured_data = data
+            .to_valid_structure(vec![string_field, text_field], DataContext::default())
+            .unwrap();
+
+        let file_contents = format_toml_frontmatter_file(structured_data);
+
+        assert_eq!(file_contents, expected);
+    }
+    #[test]
+    fn single_object_string_field() {
+        let text_field = InputField::String {
+            name: "title".to_string(),
+        };
+        let obj_field = InputField::Object {
+            name: "extra".to_string(),
+            input_fields: vec![text_field],
+        };
+        let val = PostTypes::String("Hello extra World!".to_string());
+
+        let mut fields_hm = HashMap::new();
+        fields_hm.insert("title".to_string(), val);
+        let obj_val = PostTypes::Object(fields_hm);
+        let mut obj_hm = HashMap::new();
+        obj_hm.insert("extra".to_string(), obj_val);
+
+        let data = Blob { fields: obj_hm };
+
+        let expected = r#"+++
+[extra]
+title = "Hello extra World!"
++++
+"#;
+
+        let structured_data = data
+            .to_valid_structure(vec![obj_field], DataContext::default())
+            .unwrap();
+
+        let file_contents = format_toml_frontmatter_file(structured_data);
+
+        assert_eq!(file_contents, expected);
+    }
+}

--- a/w2z.toml.example
+++ b/w2z.toml.example
@@ -5,41 +5,7 @@ client_id = "w2z"
 client_secret = "[[CLIENT_SECRET]]"
 
 [github]
-token = "github_pat_..."
-owner = "repo_owner"
-repository = "repo_name"
-branch = "test"
-
-[templates]
-[templates.note]
-path = "content/notes/{{ now() | date(format=\"%Y/%Y-%m-%dT%H:%M:%SZ\")}}-{{uuid}}.md"
-body = """
-+++
-+++
-
-{{contents}}
-"""
-
-[templates.reply]
-path = "content/replies/{{ now() | date(format=\"%Y/%Y-%m-%dT%H:%M:%SZ\")}}-{{uuid}}.md"
-
-body = """
-+++
-[extra]
-in_reply_to = "{{in_reply_to}}"
-+++
-
-{{contents}}
-"""
-
-[templates.like]
-path = "content/likes/{{ now() | date(format=\"%Y/%Y-%m-%dT%H:%M:%SZ\")}}-{{uuid}}.md"
-
-body = """
-+++
-[extra]
-in_like_of = "{{in_like_of}}"
-+++
-
-{{contents}}
-"""
+app_id = [[GITHUB_APP_ID]]
+app_key = '''-----BEGIN RSA PRIVATE KEY-----
+...
+-----END RSA PRIVATE KEY-----'''


### PR DESCRIPTION
Extract to a "backend" that can house any backend specific code for interacting with Github. Start to build more domain objects to clean up the language used.

This will hopefully allow a cleaner way to display multiple repositories as targets for the CMS side of things and dynamically loading it (in the github case) based on installations in Github