### PR TITLE
fix: Hide list fields and fix remove then add

### DIFF
--- a/src/backends/github.rs
+++ b/src/backends/github.rs
@@ -192,7 +192,7 @@ pub async fn axum_get_site(
               div class="hidden" {
                 form method="post" action={(&path_pref) "/new/" (template.0)} {
                   @for input_field in &template.1.input_fields {
-                      (input_field.form_markup(&field_prefix, templating::FormLabel::Yes))
+                      (input_field.form_markup(&field_prefix, templating::FormInputOptions::default()))
                       br {}
                   }
                   input type="submit" class="border" {}


### PR DESCRIPTION
Removing all list items would make it impossible to add one. The existing item was used as a template for the next one.

Now include a hidden field that will be used as the template, copy it, then enable it when adding